### PR TITLE
Introduce scale factor for image generation and PNG export

### DIFF
--- a/chemcanvas/main.py
+++ b/chemcanvas/main.py
@@ -715,7 +715,7 @@ class Window(QMainWindow, Ui_MainWindow):
 
     def exportAsPNG(self):
         App.tool.clear()
-        image = App.paper.getImage()
+        image = App.paper.getImage(scale = 5) # Apply a scale factor of 5 to increase resolution of output png
         if image.isNull():
             return
         path = self.getSaveFileName("png")

--- a/chemcanvas/paper.py
+++ b/chemcanvas/paper.py
@@ -517,9 +517,9 @@ class Paper(QGraphicsScene):
 
     # ------------------------ OTHERS --------------------------
 
-    def getImage(self, margin=10):
+    def getImage(self, margin=10, scale=1):
         x1, y1, w, h = map(int, self.sceneRect().getCoords())
-        image = QImage(w, h, QImage.Format_RGB32)
+        image = QImage(w * scale, h * scale, QImage.Format_RGB32)
         image.fill(Qt.white)
 
         painter = QPainter(image)
@@ -527,9 +527,9 @@ class Paper(QGraphicsScene):
         self.render(painter)
         painter.end()
 
-        x1, y1, x2, y2 = map(int, self.allObjectsBoundingBox())
+        x1, y1, x2, y2 = map(lambda x: x * scale, map(int, self.allObjectsBoundingBox()))
         x1, y1 = max(x1-margin, 0), max(y1-margin, 0)
-        x2, y2 = min(x2+margin,w), min(y2+margin, h)
+        x2, y2 = min(x2+margin,w * scale), min(y2+margin, h * scale)
         image = image.copy(x1, y1, x2-x1, y2-y1)
         return image
 


### PR DESCRIPTION
Added a scale factor to the getImage function to allow for higher resolutions when rendering the canvas image. This feature is then used in the export PNG function to generate PNGs with resolutions above 100 pixels :) 

This way, I can use the generated images in slides, manuscripts, and teaching materials.

A scaling factor of 5 is hardcoded for PNG export for now, but can be added as a user option in future.